### PR TITLE
Disable JavaScript output

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Add the following to your `build.gradle.kts` file to install KtDiscord:
 
 ```kotlin
 dependencies {
-    implementation("cloud.drakon:ktdiscord:6.0.0-SNAPSHOT")
+    implementation("cloud.drakon:ktdiscord:6.0.0")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # KtDiscord
 
-[![Kotlin](https://img.shields.io/badge/kotlin-1.8.10-blue.svg?logo=kotlin)](http://kotlinlang.org)
+[![Kotlin](https://img.shields.io/badge/kotlin-1.8.20-blue.svg?logo=kotlin)](http://kotlinlang.org)
 [![License](https://img.shields.io/github/license/TempestProject/KtDiscord)](https://www.gnu.org/licenses/agpl-3.0.en.html)
 
 KtDiscord is a Kotlin Multiplatform library for working with Discord Interactions.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Kotlin](https://img.shields.io/badge/kotlin-1.8.10-blue.svg?logo=kotlin)](http://kotlinlang.org)
 [![License](https://img.shields.io/github/license/TempestProject/KtDiscord)](https://www.gnu.org/licenses/agpl-3.0.en.html)
 
-KtDiscord is a Kotlin Multiplatform and JavaScript/TypeScript library for working with Discord Interactions.
+KtDiscord is a Kotlin Multiplatform library for working with Discord Interactions.
 
 ## Features
 
@@ -14,30 +14,14 @@ KtDiscord is a Kotlin Multiplatform and JavaScript/TypeScript library for workin
 
 ## Installation
 
-KtDiscord is available from Maven Central (for Kotlin) and npm (for JavaScript/TypeScript).
-
-### Kotlin
+KtDiscord is available from Maven Central.
 
 Add the following to your `build.gradle.kts` file to install KtDiscord:
 
 ```kotlin
 dependencies {
-    implementation("cloud.drakon:ktdiscord:5.2.0")
+    implementation("cloud.drakon:ktdiscord:6.0.0-SNAPSHOT")
 }
-```
-
-### JavaScript/TypeScript
-
-### `package.json`
-
-```json
-"@tempestproject/ktdiscord": "5.2.0"
-```
-
-#### Command line
-
-```commandline
-npm install @tempestproject/ktdiscord
 ```
 
 ## Stability

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "cloud.drakon"
-version = "6.0.0-SNAPSHOT"
+version = "6.0.0"
 
 repositories {
     mavenCentral()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,13 +5,14 @@ plugins {
     id("maven-publish")
     id("io.github.gradle-nexus.publish-plugin") version "1.3.0"
     signing
-    id("dev.petuska.npm.publish") version "3.2.1"
+
+    //    id("dev.petuska.npm.publish") version "3.2.1"
 
     id("org.jetbrains.dokka") version "1.8.10"
 }
 
 group = "cloud.drakon"
-version = "5.2.0"
+version = "6.0.0-SNAPSHOT"
 
 repositories {
     mavenCentral()
@@ -29,7 +30,8 @@ kotlin {
     js(IR) {
         nodejs()
         useCommonJs()
-        binaries.library()
+
+        //        binaries.library()
     }
 
     sourceSets {
@@ -119,7 +121,7 @@ signing {
     sign(publishing.publications)
 }
 
-npmPublish {
+/*npmPublish {
     organization.set("tempestproject")
     packages {
         named("js") {
@@ -144,7 +146,7 @@ npmPublish {
             authToken.set(System.getenv("NPM_ACCESS_TOKEN"))
         }
     }
-}
+}*/
 
 tasks.dokkaJekyll.configure {
     outputDirectory.set(buildDir.resolve("dokka"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    kotlin("multiplatform") version "1.8.10"
-    kotlin("plugin.serialization") version "1.8.10"
+    kotlin("multiplatform") version "1.8.20"
+    kotlin("plugin.serialization") version "1.8.20"
 
     id("maven-publish")
     id("io.github.gradle-nexus.publish-plugin") version "1.3.0"

--- a/src/commonMain/kotlin/KtDiscord.kt
+++ b/src/commonMain/kotlin/KtDiscord.kt
@@ -2,7 +2,7 @@ package cloud.drakon.ktdiscord
 
 import io.ktor.client.statement.HttpResponse
 
-internal const val VERSION = "6.0.0-SNAPSHOT"
+internal const val VERSION = "6.0.0"
 
 expect class KtDiscord(applicationId: String, botToken: String) {
     inner class Interaction

--- a/src/commonMain/kotlin/KtDiscord.kt
+++ b/src/commonMain/kotlin/KtDiscord.kt
@@ -4,7 +4,7 @@ import io.ktor.client.statement.HttpResponse
 
 internal const val VERSION = "6.0.0-SNAPSHOT"
 
-expect class KtDiscordClient(applicationId: String, botToken: String) {
+expect class KtDiscord(applicationId: String, botToken: String) {
     inner class Interaction
 
     inner class ApplicationCommands {

--- a/src/commonMain/kotlin/KtDiscordClient.kt
+++ b/src/commonMain/kotlin/KtDiscordClient.kt
@@ -2,7 +2,7 @@ package cloud.drakon.ktdiscord
 
 import io.ktor.client.statement.HttpResponse
 
-internal const val VERSION = "5.2.0"
+internal const val VERSION = "6.0.0-SNAPSHOT"
 
 expect class KtDiscordClient(applicationId: String, botToken: String) {
     inner class Interaction

--- a/src/commonMain/kotlin/application/Application.kt
+++ b/src/commonMain/kotlin/application/Application.kt
@@ -2,7 +2,6 @@ package cloud.drakon.ktdiscord.application
 
 import cloud.drakon.ktdiscord.teams.Team
 import cloud.drakon.ktdiscord.user.User
-import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -29,7 +28,7 @@ import kotlinx.serialization.Serializable
  * @property installParams settings for the application's default in-app authorization link, if enabled
  * @property customInstallUrl the application's default custom authorization link, if enabled
  */
-@JsExport @Serializable class Application(
+@Serializable class Application(
     val id: String,
     val name: String,
     val icon: String?,

--- a/src/commonMain/kotlin/application/InstallParams.kt
+++ b/src/commonMain/kotlin/application/InstallParams.kt
@@ -1,13 +1,12 @@
 package cloud.drakon.ktdiscord.application
 
-import kotlin.js.JsExport
 import kotlinx.serialization.Serializable
 
 /**
  * @property scopes the scopes to add the application to the server with
  * @property permissions the permissions to request for the bot role
  */
-@JsExport @Serializable class InstallParams(
+@Serializable class InstallParams(
     val scopes: Array<String>,
     val permissions: String,
 )

--- a/src/commonMain/kotlin/applicationcommand/ApplicationCommand.kt
+++ b/src/commonMain/kotlin/applicationcommand/ApplicationCommand.kt
@@ -1,7 +1,6 @@
 package cloud.drakon.ktdiscord.applicationcommand
 
 import cloud.drakon.ktdiscord.applicationcommand.option.ApplicationCommandOption
-import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -23,7 +22,7 @@ import kotlinx.serialization.Serializable
  * @property nsfw Indicates whether the command is age-restricted, defaults to `false`
  * @property version Autoincrementing version identifier updated during substantial record changes
  */
-@JsExport @Serializable class ApplicationCommand(
+@Serializable class ApplicationCommand(
     val id: String,
     val type: Byte? = null,
     @SerialName("application_id") val applicationId: String,

--- a/src/commonMain/kotlin/applicationcommand/ApplicationCommandCreate.kt
+++ b/src/commonMain/kotlin/applicationcommand/ApplicationCommandCreate.kt
@@ -1,7 +1,6 @@
 package cloud.drakon.ktdiscord.applicationcommand
 
 import cloud.drakon.ktdiscord.applicationcommand.option.ApplicationCommandOption
-import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -19,7 +18,7 @@ import kotlinx.serialization.Serializable
  * @property type Type of command, defaults to `1`
  * @property nsfw Indicates whether the command is age-restricted, defaults to `false`
  */
-@JsExport @Serializable class ApplicationCommandCreate(
+@Serializable class ApplicationCommandCreate(
     val name: String,
     @SerialName("name_localizations")
     val nameLocalizations: Map<String, String>? = null,

--- a/src/commonMain/kotlin/applicationcommand/ApplicationCommandEdit.kt
+++ b/src/commonMain/kotlin/applicationcommand/ApplicationCommandEdit.kt
@@ -1,7 +1,6 @@
 package cloud.drakon.ktdiscord.applicationcommand
 
 import cloud.drakon.ktdiscord.applicationcommand.option.ApplicationCommandOption
-import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -19,7 +18,7 @@ import kotlinx.serialization.Serializable
  * @property type Type of command, defaults to `1`
  * @property nsfw Indicates whether the command is age-restricted, defaults to `false`
  */
-@JsExport @Serializable class ApplicationCommandEdit(
+@Serializable class ApplicationCommandEdit(
     val name: String? = null,
     @SerialName("name_localizations")
     val nameLocalizations: Map<String, String>? = null,

--- a/src/commonMain/kotlin/applicationcommand/ApplicationCommandType.kt
+++ b/src/commonMain/kotlin/applicationcommand/ApplicationCommandType.kt
@@ -1,8 +1,6 @@
 package cloud.drakon.ktdiscord.applicationcommand
 
-import kotlin.js.JsExport
-
-@JsExport object ApplicationCommandType {
+object ApplicationCommandType {
     const val CHAT_INPUT: Byte = 1
     const val USER: Byte = 2
     const val MESSAGE: Byte = 3

--- a/src/commonMain/kotlin/applicationcommand/option/ApplicationCommandOption.kt
+++ b/src/commonMain/kotlin/applicationcommand/option/ApplicationCommandOption.kt
@@ -1,6 +1,5 @@
 package cloud.drakon.ktdiscord.applicationcommand.option
 
-import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -20,7 +19,7 @@ import kotlinx.serialization.Serializable
  * @property maxLength For option type `STRING`, the maximum allowed length (minimum of `1`, maximum of `6000`)
  * @property autocomplete If autocomplete interactions are enabled for this `STRING`, `INTEGER`, or `NUMBER` type option
  */
-@JsExport @Serializable class ApplicationCommandOption(
+@Serializable class ApplicationCommandOption(
     val type: Byte,
     val name: String,
     @SerialName("name_localizations") val nameLocalizations: Map<String, String>,

--- a/src/commonMain/kotlin/applicationcommand/option/ApplicationCommandOptionChoice.kt
+++ b/src/commonMain/kotlin/applicationcommand/option/ApplicationCommandOptionChoice.kt
@@ -1,6 +1,5 @@
 package cloud.drakon.ktdiscord.applicationcommand.option
 
-import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -10,7 +9,7 @@ import kotlinx.serialization.Serializable
  * @property nameLocalizations Localization dictionary for the `name` field. Values follow the same restrictions as `name`
  * @property value Value for the choice, up to 100 characters if string
  */
-@JsExport @Serializable class ApplicationCommandOptionChoice(
+@Serializable class ApplicationCommandOptionChoice(
     val name: String,
     @SerialName("name_localizations") val nameLocalizations: Map<String, String>,
     val value: String,

--- a/src/commonMain/kotlin/applicationcommand/option/ApplicationCommandOptionType.kt
+++ b/src/commonMain/kotlin/applicationcommand/option/ApplicationCommandOptionType.kt
@@ -1,8 +1,6 @@
 package cloud.drakon.ktdiscord.applicationcommand.option
 
-import kotlin.js.JsExport
-
-@JsExport object ApplicationCommandOptionType {
+object ApplicationCommandOptionType {
     const val SUB_COMMAND: Byte = 1
     const val SUB_COMMAND_GROUP: Byte = 2
     const val STRING: Byte = 3

--- a/src/commonMain/kotlin/applicationcommand/permissions/ApplicationCommandPermissionConstants.kt
+++ b/src/commonMain/kotlin/applicationcommand/permissions/ApplicationCommandPermissionConstants.kt
@@ -1,8 +1,6 @@
 package cloud.drakon.ktdiscord.applicationcommand.permissions
 
-import kotlin.js.JsExport
-
-@JsExport object ApplicationCommandPermissionConstants {
+object ApplicationCommandPermissionConstants {
     /** All members in a guild */
     const val everyone = "guild_id"
 

--- a/src/commonMain/kotlin/applicationcommand/permissions/ApplicationCommandPermissions.kt
+++ b/src/commonMain/kotlin/applicationcommand/permissions/ApplicationCommandPermissions.kt
@@ -1,6 +1,5 @@
 package cloud.drakon.ktdiscord.applicationcommand.permissions
 
-import kotlin.js.JsExport
 import kotlinx.serialization.Serializable
 
 /**
@@ -10,7 +9,7 @@ import kotlinx.serialization.Serializable
  * @property type role (`1`), user (`2`), or channel (`3`)
  * @property permission `true` to allow, `false` to disallow
  */
-@JsExport @Serializable class ApplicationCommandPermissions(
+@Serializable class ApplicationCommandPermissions(
     val id: String,
     val type: Byte,
     val permission: Boolean,

--- a/src/commonMain/kotlin/applicationcommand/permissions/GuildApplicationCommandPermissions.kt
+++ b/src/commonMain/kotlin/applicationcommand/permissions/GuildApplicationCommandPermissions.kt
@@ -1,6 +1,5 @@
 package cloud.drakon.ktdiscord.applicationcommand.permissions
 
-import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -14,7 +13,7 @@ import kotlinx.serialization.Serializable
  * @property guildId ID of the guild
  * @property permissions Permissions for the command in the guild, max of 100
  */
-@JsExport @Serializable class GuildApplicationCommandPermissions(
+@Serializable class GuildApplicationCommandPermissions(
     val id: String,
     @SerialName("application_id") val applicationId: String,
     @SerialName("guild_id") val guildId: String,

--- a/src/commonMain/kotlin/channel/Attachment.kt
+++ b/src/commonMain/kotlin/channel/Attachment.kt
@@ -1,6 +1,5 @@
 package cloud.drakon.ktdiscord.channel
 
-import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -16,7 +15,7 @@ import kotlinx.serialization.Serializable
  * @property width width of file (if image)
  * @property ephemeral whether this attachment is ephemeral
  */
-@JsExport @Serializable class Attachment(
+@Serializable class Attachment(
     val id: String,
     val filename: String,
     val description: String? = null,

--- a/src/commonMain/kotlin/channel/Channel.kt
+++ b/src/commonMain/kotlin/channel/Channel.kt
@@ -1,6 +1,5 @@
 package cloud.drakon.ktdiscord.channel
 
-import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -10,7 +9,7 @@ import kotlinx.serialization.Serializable
  * @property guildId the id of the guild
  * @property position sorting position of the channel
  */
-@JsExport @Serializable class Channel(
+@Serializable class Channel(
     val id: String,
     val type: Byte,
     @SerialName("guild_id") val guildId: String? = null,

--- a/src/commonMain/kotlin/channel/ChannelMention.kt
+++ b/src/commonMain/kotlin/channel/ChannelMention.kt
@@ -1,6 +1,5 @@
 package cloud.drakon.ktdiscord.channel
 
-import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -10,7 +9,7 @@ import kotlinx.serialization.Serializable
  * @property type the type of channel
  * @property name the name of the channel
  */
-@JsExport @Serializable class ChannelMention(
+@Serializable class ChannelMention(
     val id: String,
     @SerialName("guild_id") val guildId: String,
     val type: Byte,

--- a/src/commonMain/kotlin/channel/Overwrite.kt
+++ b/src/commonMain/kotlin/channel/Overwrite.kt
@@ -1,6 +1,5 @@
 package cloud.drakon.ktdiscord.channel
 
-import kotlin.js.JsExport
 import kotlinx.serialization.Serializable
 
 /**
@@ -9,7 +8,7 @@ import kotlinx.serialization.Serializable
  * @property allow permission bit set
  * @property deny permission bit set
  */
-@JsExport @Serializable class Overwrite(
+@Serializable class Overwrite(
     val id: String,
     val type: Byte,
     val allow: String,

--- a/src/commonMain/kotlin/channel/Reaction.kt
+++ b/src/commonMain/kotlin/channel/Reaction.kt
@@ -1,7 +1,6 @@
 package cloud.drakon.ktdiscord.channel
 
 import cloud.drakon.ktdiscord.emoji.Emoji
-import kotlin.js.JsExport
 import kotlinx.serialization.Serializable
 
 /**
@@ -9,7 +8,7 @@ import kotlinx.serialization.Serializable
  * @property me whether the current user reacted using this emoji
  * @property emoji emoji information
  */
-@JsExport @Serializable class Reaction(
+@Serializable class Reaction(
     val count: Int,
     val me: Boolean,
     val emoji: Emoji,

--- a/src/commonMain/kotlin/channel/allowedmentions/AllowedMentionTypes.kt
+++ b/src/commonMain/kotlin/channel/allowedmentions/AllowedMentionTypes.kt
@@ -1,8 +1,6 @@
 package cloud.drakon.ktdiscord.channel.allowedmentions
 
-import kotlin.js.JsExport
-
-@JsExport object AllowedMentionTypes {
+object AllowedMentionTypes {
     /** Controls role mentions */
     const val ROLE_MENTIONS: String = "roles"
 

--- a/src/commonMain/kotlin/channel/allowedmentions/AllowedMentions.kt
+++ b/src/commonMain/kotlin/channel/allowedmentions/AllowedMentions.kt
@@ -1,13 +1,12 @@
 package cloud.drakon.ktdiscord.channel.allowedmentions
 
-import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
  * The allowed mention field allows for more granular control over mentions without various hacks to the message content. This will always validate against message content to avoid phantom pings (e.g. to ping everyone, you must still have `@everyone` in the message content), and check against user/bot permissions.
  */
-@JsExport @Serializable class AllowedMentions(
+@Serializable class AllowedMentions(
     val parse: Array<String>,
     val roles: Array<String>,
     val users: Array<String>,

--- a/src/commonMain/kotlin/channel/embed/Embed.kt
+++ b/src/commonMain/kotlin/channel/embed/Embed.kt
@@ -1,6 +1,5 @@
 package cloud.drakon.ktdiscord.channel.embed
 
-import kotlin.js.JsExport
 import kotlinx.serialization.Serializable
 
 /**
@@ -18,7 +17,7 @@ import kotlinx.serialization.Serializable
  * @property author author information
  * @property fields fields information
  */
-@JsExport @Serializable class Embed(
+@Serializable class Embed(
     val title: String? = null,
     val type: String? = null,
     val description: String? = null,

--- a/src/commonMain/kotlin/channel/embed/EmbedAuthor.kt
+++ b/src/commonMain/kotlin/channel/embed/EmbedAuthor.kt
@@ -1,6 +1,5 @@
 package cloud.drakon.ktdiscord.channel.embed
 
-import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -10,7 +9,7 @@ import kotlinx.serialization.Serializable
  * @property iconUrl url of author icon (only supports http(s) and attachments)
  * @property proxyIconUrl a proxied url of author icon
  */
-@JsExport @Serializable class EmbedAuthor(
+@Serializable class EmbedAuthor(
     val name: String,
     val url: String? = null,
     @SerialName("icon_url") val iconUrl: String? = null,

--- a/src/commonMain/kotlin/channel/embed/EmbedField.kt
+++ b/src/commonMain/kotlin/channel/embed/EmbedField.kt
@@ -1,6 +1,5 @@
 package cloud.drakon.ktdiscord.channel.embed
 
-import kotlin.js.JsExport
 import kotlinx.serialization.Serializable
 
 /**
@@ -8,7 +7,7 @@ import kotlinx.serialization.Serializable
  * @property value value of the field
  * @property inline whether or not this field should display inline
  */
-@JsExport @Serializable class EmbedField(
+@Serializable class EmbedField(
     val name: String,
     val value: String,
     val inline: Boolean? = null,

--- a/src/commonMain/kotlin/channel/embed/EmbedFooter.kt
+++ b/src/commonMain/kotlin/channel/embed/EmbedFooter.kt
@@ -1,6 +1,5 @@
 package cloud.drakon.ktdiscord.channel.embed
 
-import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -9,7 +8,7 @@ import kotlinx.serialization.Serializable
  * @property iconUrl url of footer icon (only supports http(s) and attachments)
  * @property proxyIconUrl a proxied url of footer icon
  */
-@JsExport @Serializable class EmbedFooter(
+@Serializable class EmbedFooter(
     val text: String,
     @SerialName("icon_url") val iconUrl: String? = null,
     @SerialName("proxy_icon_url") val proxyIconUrl: String? = null,

--- a/src/commonMain/kotlin/channel/embed/EmbedImage.kt
+++ b/src/commonMain/kotlin/channel/embed/EmbedImage.kt
@@ -1,6 +1,5 @@
 package cloud.drakon.ktdiscord.channel.embed
 
-import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -10,7 +9,7 @@ import kotlinx.serialization.Serializable
  * @property height height of image
  * @property width width of image
  */
-@JsExport @Serializable class EmbedImage(
+@Serializable class EmbedImage(
     val url: String,
     @SerialName("proxy_url") val proxyUrl: String? = null,
     val height: Short? = null,

--- a/src/commonMain/kotlin/channel/embed/EmbedProvider.kt
+++ b/src/commonMain/kotlin/channel/embed/EmbedProvider.kt
@@ -1,13 +1,12 @@
 package cloud.drakon.ktdiscord.channel.embed
 
-import kotlin.js.JsExport
 import kotlinx.serialization.Serializable
 
 /**
  * @property name name of provider
  * @property url url of provider
  */
-@JsExport @Serializable class EmbedProvider(
+@Serializable class EmbedProvider(
     val name: String? = null,
     val url: String? = null,
 )

--- a/src/commonMain/kotlin/channel/embed/EmbedThumbnail.kt
+++ b/src/commonMain/kotlin/channel/embed/EmbedThumbnail.kt
@@ -1,6 +1,5 @@
 package cloud.drakon.ktdiscord.channel.embed
 
-import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -10,7 +9,7 @@ import kotlinx.serialization.Serializable
  * @property height height of thumbnail
  * @property width width of thumbnail
  */
-@JsExport @Serializable class EmbedThumbnail(
+@Serializable class EmbedThumbnail(
     val url: String,
     @SerialName("proxy_url") val proxyUrl: String? = null,
     val height: Short? = null,

--- a/src/commonMain/kotlin/channel/embed/EmbedVideo.kt
+++ b/src/commonMain/kotlin/channel/embed/EmbedVideo.kt
@@ -1,6 +1,5 @@
 package cloud.drakon.ktdiscord.channel.embed
 
-import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -10,7 +9,7 @@ import kotlinx.serialization.Serializable
  * @property height height of video
  * @property width width of video
  */
-@JsExport @Serializable class EmbedVideo(
+@Serializable class EmbedVideo(
     val url: String,
     @SerialName("proxy_url") val proxyUrl: String? = null,
     val height: Short? = null,

--- a/src/commonMain/kotlin/channel/message/Message.kt
+++ b/src/commonMain/kotlin/channel/message/Message.kt
@@ -12,7 +12,6 @@ import cloud.drakon.ktdiscord.permissions.Role
 import cloud.drakon.ktdiscord.sticker.Sticker
 import cloud.drakon.ktdiscord.sticker.StickerItem
 import cloud.drakon.ktdiscord.user.User
-import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -49,7 +48,7 @@ import kotlinx.serialization.Serializable
  * @property stickers **Deprecated** the stickers sent with the message
  * @property position A generally increasing integer (there may be gaps or duplicates) that represents the approximate position of the message in a thread, it can be used to estimate the relative position of the message in a thread in company with `total_message_sent` on parent thread
  */
-@JsExport @Serializable class Message(
+@Serializable class Message(
     val id: String,
     @SerialName("channel_id") val channelId: String,
     val author: User,

--- a/src/commonMain/kotlin/channel/message/MessageActivity.kt
+++ b/src/commonMain/kotlin/channel/message/MessageActivity.kt
@@ -1,6 +1,5 @@
 package cloud.drakon.ktdiscord.channel.message
 
-import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -8,7 +7,7 @@ import kotlinx.serialization.Serializable
  * @property type type of message activity
  * @property partyId party_id from a Rich Presence event
  */
-@JsExport @Serializable class MessageActivity(
+@Serializable class MessageActivity(
     val type: Byte,
     @SerialName("party_id") val partyId: String? = null,
 )

--- a/src/commonMain/kotlin/channel/message/MessageFlags.kt
+++ b/src/commonMain/kotlin/channel/message/MessageFlags.kt
@@ -1,8 +1,6 @@
 package cloud.drakon.ktdiscord.channel.message
 
-import kotlin.js.JsExport
-
-@JsExport object MessageFlags {
+object MessageFlags {
     const val SUPPRESS_EMBEDS: Byte = 1 shl 2
     const val EPHEMERAL: Byte = 1 shl 6
 }

--- a/src/commonMain/kotlin/channel/message/MessageReference.kt
+++ b/src/commonMain/kotlin/channel/message/MessageReference.kt
@@ -1,6 +1,5 @@
 package cloud.drakon.ktdiscord.channel.message
 
-import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -10,7 +9,7 @@ import kotlinx.serialization.Serializable
  * @property guildId id of the originating message's guild
  * @property failIfNotExists when sending, whether to error if the referenced message doesn't exist instead of sending as a normal (non-reply) message, default true
  */
-@JsExport @Serializable class MessageReference(
+@Serializable class MessageReference(
     @SerialName("message_id") val messageId: String? = null,
     @SerialName("channel_id") val channelId: String? = null,
     @SerialName("guild_id") val guildId: String? = null,

--- a/src/commonMain/kotlin/components/ActionRow.kt
+++ b/src/commonMain/kotlin/components/ActionRow.kt
@@ -1,6 +1,5 @@
 package cloud.drakon.ktdiscord.components
 
-import kotlin.js.JsExport
 import kotlinx.serialization.Serializable
 
 /**
@@ -8,6 +7,6 @@ import kotlinx.serialization.Serializable
  * - You can have up to 5 Action Rows per message
  * - An Action Row cannot contain another Action Row
  */
-@JsExport @Serializable class ActionRow(val components: Array<Component>): Component {
+@Serializable class ActionRow(val components: Array<Component>): Component {
     val type: Byte = 1
 }

--- a/src/commonMain/kotlin/components/Button.kt
+++ b/src/commonMain/kotlin/components/Button.kt
@@ -1,7 +1,6 @@
 package cloud.drakon.ktdiscord.components
 
 import cloud.drakon.ktdiscord.emoji.Emoji
-import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -11,7 +10,7 @@ import kotlinx.serialization.Serializable
  * - An Action Row can contain up to 5 buttons
  * - An Action Row containing buttons cannot also contain any select menu components
  */
-@JsExport @Serializable class Button(
+@Serializable class Button(
     val style: Byte,
     val label: String? = null,
     val emoji: Emoji? = null,

--- a/src/commonMain/kotlin/components/Component.kt
+++ b/src/commonMain/kotlin/components/Component.kt
@@ -1,10 +1,8 @@
 package cloud.drakon.ktdiscord.components
 
-import kotlin.js.JsExport
-
 /**
  * Components are a new field on the message object, so you can use them whether you're sending messages or responding to a slash command or other interaction.
  *
  * The top-level `components` field is an array of Action Row components.
  */
-@JsExport interface Component
+interface Component

--- a/src/commonMain/kotlin/components/selectmenu/ChannelSelectMenu.kt
+++ b/src/commonMain/kotlin/components/selectmenu/ChannelSelectMenu.kt
@@ -1,6 +1,5 @@
 package cloud.drakon.ktdiscord.components.selectmenu
 
-import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,7 +11,7 @@ import kotlinx.serialization.Serializable
  * @property maxValues Maximum number of items that can be chosen (defaults to 1); max 25
  * @property disabled Whether select menu is disabled (defaults to `false`)
  */
-@JsExport @Serializable class ChannelSelectMenu(
+@Serializable class ChannelSelectMenu(
     @SerialName("custom_id") val customId: String,
     @SerialName("channel_types") val channelTypes: ByteArray? = null,
     val placeholder: String? = null,

--- a/src/commonMain/kotlin/components/selectmenu/MentionableSelectMenu.kt
+++ b/src/commonMain/kotlin/components/selectmenu/MentionableSelectMenu.kt
@@ -1,6 +1,5 @@
 package cloud.drakon.ktdiscord.components.selectmenu
 
-import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -11,7 +10,7 @@ import kotlinx.serialization.Serializable
  * @property maxValues Maximum number of items that can be chosen (defaults to 1); max 25
  * @property disabled Whether select menu is disabled (defaults to `false`)
  */
-@JsExport @Serializable class MentionableSelectMenu(
+@Serializable class MentionableSelectMenu(
     @SerialName("custom_id") val customId: String,
     val placeholder: String? = null,
     @SerialName("min_values") val minValues: Byte? = null,

--- a/src/commonMain/kotlin/components/selectmenu/RoleSelectMenu.kt
+++ b/src/commonMain/kotlin/components/selectmenu/RoleSelectMenu.kt
@@ -1,6 +1,5 @@
 package cloud.drakon.ktdiscord.components.selectmenu
 
-import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -11,7 +10,7 @@ import kotlinx.serialization.Serializable
  * @property maxValues Maximum number of items that can be chosen (defaults to 1); max 25
  * @property disabled Whether select menu is disabled (defaults to `false`)
  */
-@JsExport @Serializable class RoleSelectMenu(
+@Serializable class RoleSelectMenu(
     @SerialName("custom_id") val customId: String,
     val placeholder: String? = null,
     @SerialName("min_values") val minValues: Byte? = null,

--- a/src/commonMain/kotlin/components/selectmenu/SelectMenu.kt
+++ b/src/commonMain/kotlin/components/selectmenu/SelectMenu.kt
@@ -1,7 +1,6 @@
 package cloud.drakon.ktdiscord.components.selectmenu
 
 import cloud.drakon.ktdiscord.components.Component
-import kotlin.js.JsExport
 
 /**
  * Select menus are interactive components that allow users to select one or more options from a dropdown list in messages. On desktop, clicking on a select menu opens a dropdown-style UI; on mobile, tapping a select menu opens up a half-sheet with the options.
@@ -11,4 +10,4 @@ import kotlin.js.JsExport
  * - An Action Row can contain only one select menu
  * - An Action Row containing a select menu cannot also contain buttons
  */
-@JsExport interface SelectMenu: Component
+interface SelectMenu: Component

--- a/src/commonMain/kotlin/components/selectmenu/SelectOption.kt
+++ b/src/commonMain/kotlin/components/selectmenu/SelectOption.kt
@@ -1,7 +1,6 @@
 package cloud.drakon.ktdiscord.components.selectmenu
 
 import cloud.drakon.ktdiscord.emoji.Emoji
-import kotlin.js.JsExport
 import kotlinx.serialization.Serializable
 
 /**
@@ -11,7 +10,7 @@ import kotlinx.serialization.Serializable
  * @property emoji `id`, `name`, and `animated`
  * @property default Will show this option as selected by default
  */
-@JsExport @Serializable class SelectOption(
+@Serializable class SelectOption(
     val label: String,
     val value: String,
     val description: String? = null,

--- a/src/commonMain/kotlin/components/selectmenu/TextSelectMenu.kt
+++ b/src/commonMain/kotlin/components/selectmenu/TextSelectMenu.kt
@@ -1,6 +1,5 @@
 package cloud.drakon.ktdiscord.components.selectmenu
 
-import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,7 +11,7 @@ import kotlinx.serialization.Serializable
  * @property maxValues Maximum number of items that can be chosen (defaults to 1); max 25
  * @property disabled Whether select menu is disabled (defaults to `false`)
  */
-@JsExport @Serializable class TextSelectMenu(
+@Serializable class TextSelectMenu(
     @SerialName("custom_id") val customId: String,
     val options: Array<SelectOption>? = null,
     val placeholder: String? = null,

--- a/src/commonMain/kotlin/components/selectmenu/UserSelectMenu.kt
+++ b/src/commonMain/kotlin/components/selectmenu/UserSelectMenu.kt
@@ -1,6 +1,5 @@
 package cloud.drakon.ktdiscord.components.selectmenu
 
-import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -11,7 +10,7 @@ import kotlinx.serialization.Serializable
  * @property maxValues Maximum number of items that can be chosen (defaults to 1); max 25
  * @property disabled Whether select menu is disabled (defaults to `false`)
  */
-@JsExport @Serializable class UserSelectMenu(
+@Serializable class UserSelectMenu(
     @SerialName("custom_id") val customId: String,
     val placeholder: String? = null,
     @SerialName("min_values") val minValues: Byte? = null,

--- a/src/commonMain/kotlin/components/textinput/TextInput.kt
+++ b/src/commonMain/kotlin/components/textinput/TextInput.kt
@@ -1,7 +1,6 @@
 package cloud.drakon.ktdiscord.components.textinput
 
 import cloud.drakon.ktdiscord.components.Component
-import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -15,7 +14,7 @@ import kotlinx.serialization.Serializable
  * @property value Pre-filled value for this component; max 4000 characters
  * @property placeholder Custom placeholder text if the input is empty; max 100 characters
  */
-@JsExport @Serializable class TextInput(
+@Serializable class TextInput(
     @SerialName("custom_id") val customId: String,
     val style: Byte,
     val label: String,

--- a/src/commonMain/kotlin/emoji/Emoji.kt
+++ b/src/commonMain/kotlin/emoji/Emoji.kt
@@ -2,7 +2,6 @@ package cloud.drakon.ktdiscord.emoji
 
 import cloud.drakon.ktdiscord.permissions.Role
 import cloud.drakon.ktdiscord.user.User
-import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -16,7 +15,7 @@ import kotlinx.serialization.Serializable
  * @property animated whether this emoji is animated
  * @property available whether this emoji can be used, may be false due to loss of Server Boosts
  */
-@JsExport @Serializable class Emoji(
+@Serializable class Emoji(
     val id: String?,
     val name: String?,
     val roles: Array<Role>? = null,

--- a/src/commonMain/kotlin/file/File.kt
+++ b/src/commonMain/kotlin/file/File.kt
@@ -1,8 +1,6 @@
 package cloud.drakon.ktdiscord.file
 
-import kotlin.js.JsExport
-
-@JsExport class File(
+class File(
     val id: String,
     val filename: String,
     val contentType: String,

--- a/src/commonMain/kotlin/guild/GuildMember.kt
+++ b/src/commonMain/kotlin/guild/GuildMember.kt
@@ -1,11 +1,10 @@
 package cloud.drakon.ktdiscord.guild
 
 import cloud.drakon.ktdiscord.user.User
-import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-@JsExport @Serializable class GuildMember(
+@Serializable class GuildMember(
     val user: User? = null,
     val nick: String? = null,
     val avatar: String? = null,

--- a/src/commonMain/kotlin/interaction/Interaction.kt
+++ b/src/commonMain/kotlin/interaction/Interaction.kt
@@ -3,7 +3,6 @@ package cloud.drakon.ktdiscord.interaction
 import cloud.drakon.ktdiscord.channel.message.Message
 import cloud.drakon.ktdiscord.guild.GuildMember
 import cloud.drakon.ktdiscord.user.User
-import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -30,7 +29,7 @@ import kotlinx.serialization.Serializable
  * @property locale Selected language of the invoking user
  * @property guildLocale Guild's preferred locale, if invoked in a guild
  */
-@JsExport @Serializable class Interaction<T: InteractionData?>(
+@Serializable class Interaction<T: InteractionData?>(
     val id: String,
     @SerialName("application_id") val applicationId: String,
     val type: Int,

--- a/src/commonMain/kotlin/interaction/InteractionData.kt
+++ b/src/commonMain/kotlin/interaction/InteractionData.kt
@@ -1,7 +1,5 @@
 package cloud.drakon.ktdiscord.interaction
 
-import kotlin.js.JsExport
-
 /**
  * An Interaction is the message that your application receives when a user uses an application command or a message component.
  *
@@ -11,4 +9,4 @@ import kotlin.js.JsExport
  *
  * For Message Components it includes identifying information about the component that was used. It will also include some metadata about how the interaction was triggered: the `guild_id`, `channel_id`, `member` and other fields. You can find all the values in our data models below.
  */
-@JsExport interface InteractionData
+interface InteractionData

--- a/src/commonMain/kotlin/interaction/InteractionJsonSerializer.kt
+++ b/src/commonMain/kotlin/interaction/InteractionJsonSerializer.kt
@@ -1,7 +1,6 @@
 package cloud.drakon.ktdiscord.interaction
 
 import cloud.drakon.ktdiscord.interaction.applicationcommand.ApplicationCommandData
-import kotlin.js.JsExport
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.json.JsonContentPolymorphicSerializer
 import kotlinx.serialization.json.JsonElement
@@ -9,10 +8,9 @@ import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
-@JsExport object InteractionJsonSerializer:
-    JsonContentPolymorphicSerializer<Interaction<*>>(
-        Interaction::class
-    ) {
+object InteractionJsonSerializer: JsonContentPolymorphicSerializer<Interaction<*>>(
+    Interaction::class
+) {
     override fun selectDeserializer(element: JsonElement): DeserializationStrategy<out Interaction<*>> {
         return when (val type = element.jsonObject["type"]?.jsonPrimitive?.intOrNull) {
             1    -> Interaction.serializer(Ping.serializer())

--- a/src/commonMain/kotlin/interaction/InteractionType.kt
+++ b/src/commonMain/kotlin/interaction/InteractionType.kt
@@ -1,8 +1,6 @@
 package cloud.drakon.ktdiscord.interaction
 
-import kotlin.js.JsExport
-
-@JsExport object InteractionType {
+object InteractionType {
     const val PING: Int = 1
     const val APPLICATION_COMMAND: Int = 2
     const val MESSAGE_COMPONENT: Int = 3

--- a/src/commonMain/kotlin/interaction/MessageComponentData.kt
+++ b/src/commonMain/kotlin/interaction/MessageComponentData.kt
@@ -1,7 +1,6 @@
 package cloud.drakon.ktdiscord.interaction
 
 import cloud.drakon.ktdiscord.components.selectmenu.SelectOption
-import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -10,7 +9,7 @@ import kotlinx.serialization.Serializable
  * @property componentType the type of the components
  * @property values values the user selected in a select menu components
  */
-@JsExport @Serializable class MessageComponentData(
+@Serializable class MessageComponentData(
     @SerialName("custom_id") val customId: String,
     @SerialName("component_type") val componentType: Byte,
     val values: Array<SelectOption>? = null,

--- a/src/commonMain/kotlin/interaction/MessageInteraction.kt
+++ b/src/commonMain/kotlin/interaction/MessageInteraction.kt
@@ -2,10 +2,9 @@ package cloud.drakon.ktdiscord.interaction
 
 import cloud.drakon.ktdiscord.guild.GuildMember
 import cloud.drakon.ktdiscord.user.User
-import kotlin.js.JsExport
 import kotlinx.serialization.Serializable
 
-@JsExport @Serializable class MessageInteraction(
+@Serializable class MessageInteraction(
     val id: String,
     val type: Byte,
     val name: String,

--- a/src/commonMain/kotlin/interaction/ModalSubmitData.kt
+++ b/src/commonMain/kotlin/interaction/ModalSubmitData.kt
@@ -1,7 +1,6 @@
 package cloud.drakon.ktdiscord.interaction
 
 import cloud.drakon.ktdiscord.components.Component
-import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -9,7 +8,7 @@ import kotlinx.serialization.Serializable
  * @property customId the `custom_id` of the modal
  * @property components the values submitted by the user
  */
-@JsExport @Serializable class ModalSubmitData(
+@Serializable class ModalSubmitData(
     @SerialName("custom_id") val customId: String,
     val components: Array<Component>,
 ): InteractionData

--- a/src/commonMain/kotlin/interaction/Ping.kt
+++ b/src/commonMain/kotlin/interaction/Ping.kt
@@ -1,6 +1,5 @@
 package cloud.drakon.ktdiscord.interaction
 
-import kotlin.js.JsExport
 import kotlinx.serialization.Serializable
 
-@JsExport @Serializable class Ping: InteractionData
+@Serializable class Ping: InteractionData

--- a/src/commonMain/kotlin/interaction/ResolvedData.kt
+++ b/src/commonMain/kotlin/interaction/ResolvedData.kt
@@ -6,7 +6,6 @@ import cloud.drakon.ktdiscord.channel.message.Message
 import cloud.drakon.ktdiscord.guild.GuildMember
 import cloud.drakon.ktdiscord.permissions.Role
 import cloud.drakon.ktdiscord.user.User
-import kotlin.js.JsExport
 import kotlinx.serialization.Serializable
 
 /**
@@ -18,7 +17,7 @@ import kotlinx.serialization.Serializable
  * @property messages the ids and partial Message objects
  * @property attachments the ids and attachment objects
  */
-@JsExport @Serializable class ResolvedData(
+@Serializable class ResolvedData(
     val users: Map<String, User>? = null,
     val members: Map<String, GuildMember>? = null,
     val roles: Map<String, Role>? = null,

--- a/src/commonMain/kotlin/interaction/applicationcommand/ApplicationCommandData.kt
+++ b/src/commonMain/kotlin/interaction/applicationcommand/ApplicationCommandData.kt
@@ -2,7 +2,6 @@ package cloud.drakon.ktdiscord.interaction.applicationcommand
 
 import cloud.drakon.ktdiscord.interaction.InteractionData
 import cloud.drakon.ktdiscord.interaction.ResolvedData
-import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -15,7 +14,7 @@ import kotlinx.serialization.Serializable
  * @property guildId the id of the guild the command is registered to
  * @property targetId id of the user or message targeted by a user or message command
  */
-@JsExport @Serializable class ApplicationCommandData(
+@Serializable class ApplicationCommandData(
     val id: String,
     val name: String,
     val type: Int,

--- a/src/commonMain/kotlin/interaction/applicationcommand/ApplicationCommandInteractionDataOption.kt
+++ b/src/commonMain/kotlin/interaction/applicationcommand/ApplicationCommandInteractionDataOption.kt
@@ -1,6 +1,5 @@
 package cloud.drakon.ktdiscord.interaction.applicationcommand
 
-import kotlin.js.JsExport
 import kotlinx.serialization.Serializable
 
 /**
@@ -13,7 +12,7 @@ import kotlinx.serialization.Serializable
  * @property options Present if this option is a group or subcommand
  * @property focused `true` if this option is the currently focused option for autocomplete
  */
-@JsExport @Serializable class ApplicationCommandInteractionDataOption(
+@Serializable class ApplicationCommandInteractionDataOption(
     val name: String,
     val type: Byte,
     val value: String? = null,

--- a/src/commonMain/kotlin/interaction/response/InteractionCallbackType.kt
+++ b/src/commonMain/kotlin/interaction/response/InteractionCallbackType.kt
@@ -1,8 +1,6 @@
 package cloud.drakon.ktdiscord.interaction.response
 
-import kotlin.js.JsExport
-
-@JsExport object InteractionCallbackType {
+object InteractionCallbackType {
     /** ACK a `Ping` */
     const val PONG: Byte = 1
 

--- a/src/commonMain/kotlin/interaction/response/InteractionResponse.kt
+++ b/src/commonMain/kotlin/interaction/response/InteractionResponse.kt
@@ -1,14 +1,13 @@
 package cloud.drakon.ktdiscord.interaction.response
 
 import cloud.drakon.ktdiscord.interaction.response.interactioncallbackdata.InteractionCallbackData
-import kotlin.js.JsExport
 import kotlinx.serialization.Serializable
 
 /**
  * @property type the type of response
  * @property data an optional response message
  */
-@JsExport @Serializable class InteractionResponse(
+@Serializable class InteractionResponse(
     val type: Byte,
     val data: InteractionCallbackData? = null,
 )

--- a/src/commonMain/kotlin/interaction/response/interactioncallbackdata/AutocompleteCallbackData.kt
+++ b/src/commonMain/kotlin/interaction/response/interactioncallbackdata/AutocompleteCallbackData.kt
@@ -1,12 +1,11 @@
 package cloud.drakon.ktdiscord.interaction.response.interactioncallbackdata
 
 import cloud.drakon.ktdiscord.applicationcommand.option.ApplicationCommandOptionChoice
-import kotlin.js.JsExport
 import kotlinx.serialization.Serializable
 
 /**
  * @property choices autocomplete choices (max of 25 choices)
  */
-@JsExport @Serializable
+@Serializable
 class AutocompleteCallbackData(val choices: Array<ApplicationCommandOptionChoice>):
     InteractionCallbackData

--- a/src/commonMain/kotlin/interaction/response/interactioncallbackdata/InteractionCallbackData.kt
+++ b/src/commonMain/kotlin/interaction/response/interactioncallbackdata/InteractionCallbackData.kt
@@ -1,6 +1,5 @@
 package cloud.drakon.ktdiscord.interaction.response.interactioncallbackdata
 
-import kotlin.js.JsExport
 import kotlinx.serialization.Serializable
 
-@JsExport @Serializable sealed interface InteractionCallbackData
+@Serializable sealed interface InteractionCallbackData

--- a/src/commonMain/kotlin/interaction/response/interactioncallbackdata/MessageCallbackData.kt
+++ b/src/commonMain/kotlin/interaction/response/interactioncallbackdata/MessageCallbackData.kt
@@ -4,7 +4,6 @@ import cloud.drakon.ktdiscord.channel.Attachment
 import cloud.drakon.ktdiscord.channel.allowedmentions.AllowedMentions
 import cloud.drakon.ktdiscord.channel.embed.Embed
 import cloud.drakon.ktdiscord.components.Component
-import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -17,7 +16,7 @@ import kotlinx.serialization.Serializable
  * @property components message components
  * @property attachments attachment objects with filename and description
  */
-@JsExport @Serializable class MessageCallbackData(
+@Serializable class MessageCallbackData(
     val tts: Boolean? = null,
     val content: String? = null,
     val embeds: Array<Embed>? = null,

--- a/src/commonMain/kotlin/interaction/response/interactioncallbackdata/ModalCallbackData.kt
+++ b/src/commonMain/kotlin/interaction/response/interactioncallbackdata/ModalCallbackData.kt
@@ -1,7 +1,6 @@
 package cloud.drakon.ktdiscord.interaction.response.interactioncallbackdata
 
 import cloud.drakon.ktdiscord.components.Component
-import kotlin.js.JsExport
 import kotlinx.serialization.Serializable
 
 /**
@@ -9,7 +8,7 @@ import kotlinx.serialization.Serializable
  * @property title the title of the popup modal, max 45 characters
  * @property components between 1 and 5 (inclusive) components that make up the modal
  */
-@JsExport @Serializable class ModalCallbackData(
+@Serializable class ModalCallbackData(
     val custom_id: String,
     val title: String,
     val components: Array<Component>,

--- a/src/commonMain/kotlin/permissions/Role.kt
+++ b/src/commonMain/kotlin/permissions/Role.kt
@@ -1,6 +1,5 @@
 package cloud.drakon.ktdiscord.permissions
 
-import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -18,7 +17,7 @@ import kotlinx.serialization.Serializable
  * @property mentionable whether this role is mentionable
  * @property tags the tags this role has
  */
-@JsExport @Serializable class Role(
+@Serializable class Role(
     val id: String,
     val name: String,
     val color: Int,

--- a/src/commonMain/kotlin/permissions/RoleTags.kt
+++ b/src/commonMain/kotlin/permissions/RoleTags.kt
@@ -1,6 +1,5 @@
 package cloud.drakon.ktdiscord.permissions
 
-import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -12,7 +11,7 @@ import kotlinx.serialization.Serializable
  * @property availableForPurchase whether this role is available for purchase
  * @property guildConnections whether this role is a guild's linked role
  */
-@JsExport @Serializable class RoleTags(
+@Serializable class RoleTags(
     @SerialName("bot_id") val botId: String? = null,
     @SerialName("integration_id") val integrationId: String? = null,
     @SerialName("premium_subscriber") val premiumSubscriber: Boolean? = false,

--- a/src/commonMain/kotlin/sticker/Sticker.kt
+++ b/src/commonMain/kotlin/sticker/Sticker.kt
@@ -1,6 +1,5 @@
 package cloud.drakon.ktdiscord.sticker
 
-import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -19,7 +18,7 @@ import kotlinx.serialization.Serializable
  * @property user the user that uploaded the guild sticker
  * @property sortValue the standard sticker's sort order within its pack
  */
-@JsExport @Serializable class Sticker(
+@Serializable class Sticker(
     val id: String,
     @SerialName("pack_id") val packId: String? = null,
     val name: String,

--- a/src/commonMain/kotlin/sticker/StickerItem.kt
+++ b/src/commonMain/kotlin/sticker/StickerItem.kt
@@ -1,6 +1,5 @@
 package cloud.drakon.ktdiscord.sticker
 
-import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -10,7 +9,7 @@ import kotlinx.serialization.Serializable
  * @property name name of the sticker
  * @property formatType type of sticker format
  */
-@JsExport @Serializable class StickerItem(
+@Serializable class StickerItem(
     val id: String,
     val name: String,
     @SerialName("format_type") val formatType: Byte,

--- a/src/commonMain/kotlin/teams/Team.kt
+++ b/src/commonMain/kotlin/teams/Team.kt
@@ -1,6 +1,5 @@
 package cloud.drakon.ktdiscord.teams
 
-import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -11,7 +10,7 @@ import kotlinx.serialization.Serializable
  * @property name the name of the team
  * @property ownerUserId the user id of the current team owner
  */
-@JsExport @Serializable class Team(
+@Serializable class Team(
     val icon: String?,
     val id: String,
     val members: Array<TeamMember>,

--- a/src/commonMain/kotlin/teams/TeamMember.kt
+++ b/src/commonMain/kotlin/teams/TeamMember.kt
@@ -1,7 +1,6 @@
 package cloud.drakon.ktdiscord.teams
 
 import cloud.drakon.ktdiscord.user.User
-import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -11,7 +10,7 @@ import kotlinx.serialization.Serializable
  * @property teamId the id of the parent team of which they are a member
  * @property user the avatar, discriminator, id, and username of the user
  */
-@JsExport @Serializable class TeamMember(
+@Serializable class TeamMember(
     @SerialName("membership_state") val membershipState: Byte,
     val permissions: Array<String>,
     @SerialName("team_id") val teamId: String,

--- a/src/commonMain/kotlin/user/User.kt
+++ b/src/commonMain/kotlin/user/User.kt
@@ -1,6 +1,5 @@
 package cloud.drakon.ktdiscord.user
 
-import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -35,7 +34,7 @@ import kotlinx.serialization.Serializable
  * @property premium_type the type of Nitro subscription on a user's account
  * @property public_flags the public flags on a user's account
  */
-@JsExport @Serializable class User(
+@Serializable class User(
     val id: String,
     val username: String,
     val discriminator: String,

--- a/src/commonMain/kotlin/webhook/EditWebhookMessage.kt
+++ b/src/commonMain/kotlin/webhook/EditWebhookMessage.kt
@@ -5,12 +5,11 @@ import cloud.drakon.ktdiscord.channel.allowedmentions.AllowedMentions
 import cloud.drakon.ktdiscord.channel.embed.Embed
 import cloud.drakon.ktdiscord.components.Component
 import cloud.drakon.ktdiscord.file.File
-import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 
-@JsExport @Serializable class EditWebhookMessage(
+@Serializable class EditWebhookMessage(
     val content: String? = null,
     val embeds: Array<Embed>? = null,
     @SerialName("allowed_mentions") val allowedMentions: AllowedMentions? = null,

--- a/src/commonMain/kotlin/webhook/ExecuteWebhook.kt
+++ b/src/commonMain/kotlin/webhook/ExecuteWebhook.kt
@@ -5,12 +5,11 @@ import cloud.drakon.ktdiscord.channel.allowedmentions.AllowedMentions
 import cloud.drakon.ktdiscord.channel.embed.Embed
 import cloud.drakon.ktdiscord.components.Component
 import cloud.drakon.ktdiscord.file.File
-import kotlin.js.JsExport
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 
-@JsExport @Serializable class ExecuteWebhook(
+@Serializable class ExecuteWebhook(
     val content: String? = null,
     val tts: Boolean? = null,
     val embeds: Array<Embed>? = null,

--- a/src/commonMain/kotlin/webhook/Webhook.kt
+++ b/src/commonMain/kotlin/webhook/Webhook.kt
@@ -1,10 +1,9 @@
 package cloud.drakon.ktdiscord.webhook
 
 import cloud.drakon.ktdiscord.file.File
-import kotlin.js.JsExport
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Transient
 
-@JsExport @Serializable internal sealed interface Webhook {
+@Serializable internal sealed interface Webhook {
     @Transient val files: Array<File>?
 }

--- a/src/jsMain/kotlin/KtDiscord.kt
+++ b/src/jsMain/kotlin/KtDiscord.kt
@@ -52,7 +52,7 @@ import kotlinx.coroutines.delay
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
-actual class KtDiscordClient actual constructor(
+actual class KtDiscord actual constructor(
     private val applicationId: String,
     private val botToken: String,
 ) {

--- a/src/jsMain/kotlin/KtDiscordClient.kt
+++ b/src/jsMain/kotlin/KtDiscordClient.kt
@@ -48,15 +48,11 @@ import io.ktor.http.Headers
 import io.ktor.http.HttpHeaders
 import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
-import kotlin.js.Promise
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.await
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.promise
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
-@JsExport actual class KtDiscordClient actual constructor(
+actual class KtDiscordClient actual constructor(
     private val applicationId: String,
     private val botToken: String,
 ) {
@@ -94,11 +90,11 @@ import kotlinx.serialization.json.Json
          * Create a response to an Interaction from the gateway. Body is an interaction response.
          * @exception CreateInteractionResponseException if the Discord API didn't return `204 No Content`.
          */
-        fun createInteractionResponse(
+        suspend fun createInteractionResponse(
             interactionResponse: InteractionResponse,
             interactionId: String,
             interactionToken: String,
-        ): Promise<Unit> = GlobalScope.promise {
+        ) {
             val response =
                 ktorClient.post("interactions/$interactionId/$interactionToken/callback") {
                     contentType(ContentType.Application.Json)
@@ -119,19 +115,19 @@ import kotlinx.serialization.json.Json
          * Returns the initial Interaction response.
          * @exception GetOriginalInteractionResponseException if the Discord API didn't return `200 OK`.
          */
-        fun getOriginalInteractionResponse(
+        suspend fun getOriginalInteractionResponse(
             interactionToken: String,
-        ): Promise<Message> = GlobalScope.promise {
+        ): Message {
             val response =
                 ktorClient.get("webhooks/$applicationId/$interactionToken/messages/@original")
 
-            if (response.status.value != 200 && response.status.value != 429) {
+            return if (response.status.value != 200 && response.status.value != 429) {
                 throw GetOriginalInteractionResponseException("Code: ${response.status.value}, message: ${response.body() as String}")
             } else if (response.status.value == 429) {
                 delay(rateLimitToMilliseconds(response))
-                return@promise getOriginalInteractionResponse(interactionToken).await()
+                getOriginalInteractionResponse(interactionToken)
             } else {
-                return@promise response.body()
+                response.body()
             }
         }
 
@@ -139,9 +135,9 @@ import kotlinx.serialization.json.Json
          * Edits the initial Interaction response.
          * @exception EditOriginalInteractionResponseException if the Discord API didn't return `200 OK`.
          */
-        fun editOriginalInteractionResponse(
+        suspend fun editOriginalInteractionResponse(
             editWebhookMessage: EditWebhookMessage, interactionToken: String,
-        ): Promise<Message> = GlobalScope.promise {
+        ): Message {
             val response = if (editWebhookMessage.files == null) {
                 ktorClient.patch("webhooks/$applicationId/$interactionToken/messages/@original") {
                     contentType(ContentType.Application.Json)
@@ -153,15 +149,13 @@ import kotlinx.serialization.json.Json
                 }
             }
 
-            if (response.status.value != 200 && response.status.value != 429) {
+            return if (response.status.value != 200 && response.status.value != 429) {
                 throw EditOriginalInteractionResponseException("Code: ${response.status.value}, message: ${response.body() as String}")
             } else if (response.status.value == 429) {
                 delay(rateLimitToMilliseconds(response))
-                return@promise editOriginalInteractionResponse(
-                    editWebhookMessage, interactionToken
-                ).await()
+                editOriginalInteractionResponse(editWebhookMessage, interactionToken)
             } else {
-                return@promise response.body()
+                response.body()
             }
         }
 
@@ -169,18 +163,17 @@ import kotlinx.serialization.json.Json
          * Deletes the initial Interaction response.
          * @exception DeleteOriginalInteractionResponseException if the Discord API didn't return `204 No Content`.
          */
-        fun deleteOriginalInteractionResponse(interactionToken: String): Promise<Unit> =
-            GlobalScope.promise {
-                val response =
-                    ktorClient.delete("webhooks/$applicationId/$interactionToken/messages/@original")
+        suspend fun deleteOriginalInteractionResponse(interactionToken: String) {
+            val response =
+                ktorClient.delete("webhooks/$applicationId/$interactionToken/messages/@original")
 
-                if (response.status.value != 204 && response.status.value != 429) {
-                    throw DeleteOriginalInteractionResponseException("Code: ${response.status.value}, message: ${response.body() as String}")
-                } else if (response.status.value == 429) {
-                    delay(rateLimitToMilliseconds(response))
-                    deleteOriginalInteractionResponse(interactionToken)
-                }
+            if (response.status.value != 204 && response.status.value != 429) {
+                throw DeleteOriginalInteractionResponseException("Code: ${response.status.value}, message: ${response.body() as String}")
+            } else if (response.status.value == 429) {
+                delay(rateLimitToMilliseconds(response))
+                deleteOriginalInteractionResponse(interactionToken)
             }
+        }
 
         /**
          * Create a followup message for an Interaction.
@@ -188,10 +181,10 @@ import kotlinx.serialization.json.Json
          * `flags` can be set to `64` to mark the message as ephemeral, except when it is the first followup message to a deferred Interactions Response. In that case, the `flags` field will be ignored, and the ephemerality of the message will be determined by the `flags` value in your original ACK.
          * @exception CreateFollowupMessageException if the Discord API didn't return `200 OK`.
          */
-        fun createFollowupMessage(
+        suspend fun createFollowupMessage(
             executeWebhook: ExecuteWebhook,
             interactionToken: String,
-        ): Promise<Message> = GlobalScope.promise {
+        ): Message {
             val response = if (executeWebhook.files == null) {
                 ktorClient.post("webhooks/$applicationId/$interactionToken") {
                     contentType(
@@ -207,16 +200,13 @@ import kotlinx.serialization.json.Json
                 }
             }
 
-            if (response.status.value != 200 && response.status.value != 429) {
+            return if (response.status.value != 200 && response.status.value != 429) {
                 throw CreateFollowupMessageException("Code: ${response.status.value}, message: ${response.body() as String}")
             } else if (response.status.value == 429) {
                 delay(rateLimitToMilliseconds(response))
-                return@promise createFollowupMessage(
-                    executeWebhook,
-                    interactionToken,
-                ).await()
+                createFollowupMessage(executeWebhook, interactionToken)
             } else {
-                return@promise response.body()
+                response.body()
             }
         }
 
@@ -224,20 +214,20 @@ import kotlinx.serialization.json.Json
          * Returns a followup message for an Interaction.
          * @exception GetFollowupMessageException if the Discord API didn't return `200 OK`.
          */
-        fun getFollowupMessage(
+        suspend fun getFollowupMessage(
             messageId: String,
             interactionToken: String,
-        ): Promise<Message> = GlobalScope.promise {
+        ): Message {
             val response =
                 ktorClient.get("webhooks/$applicationId/$interactionToken/messages/$messageId")
 
-            if (response.status.value != 200 && response.status.value != 429) {
+            return if (response.status.value != 200 && response.status.value != 429) {
                 throw GetFollowupMessageException("Code: ${response.status.value}, message: ${response.body() as String}")
             } else if (response.status.value == 429) {
                 delay(rateLimitToMilliseconds(response))
-                return@promise getFollowupMessage(messageId, interactionToken).await()
+                getFollowupMessage(messageId, interactionToken)
             } else {
-                return@promise response.body()
+                response.body()
             }
         }
 
@@ -245,28 +235,24 @@ import kotlinx.serialization.json.Json
          * Edits a followup message for an Interaction.
          * @exception EditFollowupMessageException if the Discord API didn't return `200 OK`.
          */
-        fun editFollowupMessage(
+        suspend fun editFollowupMessage(
             editWebhookMessage: EditWebhookMessage,
             interactionToken: String,
             messageId: String,
-        ): Promise<Message> = GlobalScope.promise {
+        ): Message {
             val response =
                 ktorClient.patch("webhooks/$applicationId/$interactionToken/messages/$messageId") {
                     contentType(ContentType.Application.Json)
                     setBody(editWebhookMessage)
                 }
 
-            if (response.status.value != 200 && response.status.value != 429) {
+            return if (response.status.value != 200 && response.status.value != 429) {
                 throw EditFollowupMessageException("Code: ${response.status.value}, message: ${response.body() as String}")
             } else if (response.status.value == 429) {
                 delay(rateLimitToMilliseconds(response))
-                return@promise editFollowupMessage(
-                    editWebhookMessage,
-                    interactionToken,
-                    messageId,
-                ).await()
+                editFollowupMessage(editWebhookMessage, interactionToken, messageId)
             } else {
-                return@promise response.body()
+                response.body()
             }
         }
 
@@ -274,10 +260,10 @@ import kotlinx.serialization.json.Json
          * Deletes a followup message for an Interaction.
          * @exception DeleteFollowupMessageException if the Discord API didn't return `204 No Content`.
          */
-        fun deleteFollowupMessage(
+        suspend fun deleteFollowupMessage(
             interactionToken: String,
             messageId: String,
-        ): Promise<Unit> = GlobalScope.promise {
+        ) {
             val response =
                 ktorClient.delete("webhooks/$applicationId/$interactionToken/messages/$messageId")
 
@@ -296,227 +282,194 @@ import kotlinx.serialization.json.Json
          * @param withLocalizations Whether to include full localization dictionaries (`name_localizations` and `description_localizations`) in the returned objects, instead of the `name_localized` and `description_localized` fields. Default `false`.
          * @exception CreateInteractionResponseException if the Discord API didn't return `200 OK`.
          */
-        fun getGlobalApplicationCommands(withLocalizations: Boolean? = null): Promise<Array<ApplicationCommand>> =
-            GlobalScope.promise {
-                val response = ktorClient.get("/applications/$applicationId/commands") {
-                    if (withLocalizations == true) {
-                        url {
-                            parameters.append(
-                                "with_localizations", "1"
-                            )
-                        }
+        suspend fun getGlobalApplicationCommands(withLocalizations: Boolean? = null): Array<ApplicationCommand> {
+            val response = ktorClient.get("/applications/$applicationId/commands") {
+                if (withLocalizations == true) {
+                    url {
+                        parameters.append(
+                            "with_localizations", "1"
+                        )
                     }
                 }
-
-                if (response.status.value != 200 && response.status.value != 429) {
-                    throw GetGlobalApplicationCommandsException("Code: ${response.status.value}, message: ${response.body() as String}")
-                } else if (response.status.value == 429) {
-                    rateLimitToMilliseconds(response)
-                    return@promise getGlobalApplicationCommands(withLocalizations).await()
-                } else {
-                    return@promise response.body()
-                }
             }
 
-        /**
-         * Create a new global command. s command will be overwritten). Returns an application command object.
-         * @exception CreateGlobalApplicationCommandException if the Discord API didn't return `200 OK` or `201 Created`.
-         */
-        fun createGlobalApplicationCommand(applicationCommand: ApplicationCommandCreate): Promise<ApplicationCommand> =
-            GlobalScope.promise {
-                val response =
-                    ktorClient.post("/applications/$applicationId/commands") {
-                        contentType(ContentType.Application.Json)
-                        setBody(applicationCommand)
-                    }
+            return if (response.status.value != 200 && response.status.value != 429) {
+                throw GetGlobalApplicationCommandsException("Code: ${response.status.value}, message: ${response.body() as String}")
+            } else if (response.status.value == 429) {
+                rateLimitToMilliseconds(response)
+                getGlobalApplicationCommands(withLocalizations)
+            } else {
+                response.body()
+            }
+        }
 
-                if (response.status.value != 200 && response.status.value != 201 && response.status.value != 429) {
-                    throw CreateGlobalApplicationCommandException("Code: ${response.status.value}, message: ${response.body() as String}")
-                } else if (response.status.value == 429) {
-                    rateLimitToMilliseconds(response)
-                    return@promise createGlobalApplicationCommand(applicationCommand).await()
-                } else {
-                    return@promise response.body()
-                }
+        suspend fun createGlobalApplicationCommand(applicationCommand: ApplicationCommandCreate): ApplicationCommand {
+            val response = ktorClient.post("/applications/$applicationId/commands") {
+                contentType(ContentType.Application.Json)
+                setBody(applicationCommand)
             }
 
-        /**
-         * Fetch a global command for your application. Returns an application command object.
-         * @exception GetGlobalApplicationCommandException if the Discord API didn't return `200 OK`.
-         */
-        fun getGlobalApplicationCommand(commandId: String): Promise<ApplicationCommand> =
-            GlobalScope.promise {
-                val response =
-                    ktorClient.get("/applications/$applicationId/commands/$commandId")
-
-                if (response.status.value != 200 && response.status.value != 429) {
-                    throw GetGlobalApplicationCommandException("Code: ${response.status.value}, message: ${response.body() as String}")
-                } else if (response.status.value == 429) {
-                    rateLimitToMilliseconds(response)
-                    return@promise getGlobalApplicationCommand(commandId).await()
-                } else {
-                    return@promise response.body()
-                }
+            return if (response.status.value != 200 && response.status.value != 201 && response.status.value != 429) {
+                throw CreateGlobalApplicationCommandException("Code: ${response.status.value}, message: ${response.body() as String}")
+            } else if (response.status.value == 429) {
+                rateLimitToMilliseconds(response)
+                createGlobalApplicationCommand(applicationCommand)
+            } else {
+                response.body()
             }
+        }
 
-        /**
-         * Edit a global command. Returns an application command object. All fields are optional, but any fields provided will entirely overwrite the existing values of those fields.
-         * @exception EditGlobalApplicationCommandException if the Discord API didn't return `200 OK`.
-         */
-        fun editGlobalApplicationCommand(
+        suspend fun getGlobalApplicationCommand(commandId: String): ApplicationCommand {
+            val response =
+                ktorClient.get("/applications/$applicationId/commands/$commandId")
+
+            return if (response.status.value != 200 && response.status.value != 429) {
+                throw GetGlobalApplicationCommandException("Code: ${response.status.value}, message: ${response.body() as String}")
+            } else if (response.status.value == 429) {
+                rateLimitToMilliseconds(response)
+                getGlobalApplicationCommand(commandId)
+            } else {
+                response.body()
+            }
+        }
+
+        suspend fun editGlobalApplicationCommand(
             commandId: String,
             applicationCommand: ApplicationCommandEdit,
-        ): Promise<ApplicationCommand> = GlobalScope.promise {
+        ): ApplicationCommand {
             val response =
                 ktorClient.patch("/applications/$applicationId/commands/$commandId") {
                     contentType(ContentType.Application.Json)
                     setBody(applicationCommand)
                 }
 
-            if (response.status.value != 200 && response.status.value != 429) {
+            return if (response.status.value != 200 && response.status.value != 429) {
                 throw EditGlobalApplicationCommandException("Code: ${response.status.value}, message: ${response.body() as String}")
             } else if (response.status.value == 429) {
                 rateLimitToMilliseconds(response)
-                return@promise editGlobalApplicationCommand(
-                    commandId, applicationCommand
-                ).await()
+                editGlobalApplicationCommand(commandId, applicationCommand)
             } else {
-                return@promise response.body()
+                response.body()
             }
         }
 
-        /**
-         * Deletes a global command.
-         * @exception DeleteGlobalApplicationCommandException if the Discord API didn't return `204 No Content`.
-         */
-        fun deleteGlobalApplicationCommand(commandId: String): Promise<Unit> =
-            GlobalScope.promise {
-                val response =
-                    ktorClient.delete("/applications/$applicationId/commands/$commandId")
+        suspend fun deleteGlobalApplicationCommand(commandId: String) {
+            val response =
+                ktorClient.delete("/applications/$applicationId/commands/$commandId")
 
-                if (response.status.value != 204 && response.status.value != 429) {
-                    throw DeleteGlobalApplicationCommandException("Code: ${response.status.value}, message: ${response.body() as String}")
-                } else if (response.status.value == 429) {
-                    rateLimitToMilliseconds(response)
-                    deleteGlobalApplicationCommand(commandId).await()
-                }
+            if (response.status.value != 204 && response.status.value != 429) {
+                throw DeleteGlobalApplicationCommandException("Code: ${response.status.value}, message: ${response.body() as String}")
+            } else if (response.status.value == 429) {
+                rateLimitToMilliseconds(response)
+                deleteGlobalApplicationCommand(commandId)
+            }
+        }
+
+        suspend fun bulkOverwriteGlobalApplicationCommands(applicationCommands: Array<ApplicationCommandCreate>): Array<ApplicationCommand> {
+            val response = ktorClient.put("/applications/$applicationId/commands") {
+                contentType(ContentType.Application.Json)
+                setBody(applicationCommands)
             }
 
-        /**
-         * Takes a list of application commands, overwriting the existing global command list for this application. Returns an array of application command objects. Commands that do not already exist will count toward daily application command create limits.
-         * @exception BulkOverwriteGlobalApplicationCommandsException if the Discord API didn't return `200 OK`.
-         */
-        fun bulkOverwriteGlobalApplicationCommands(applicationCommands: Array<ApplicationCommandCreate>): Promise<Array<ApplicationCommand>> =
-            GlobalScope.promise {
-                val response = ktorClient.put("/applications/$applicationId/commands") {
-                    contentType(ContentType.Application.Json)
-                    setBody(applicationCommands)
-                }
-
-                if (response.status.value != 200 && response.status.value != 429) {
-                    throw BulkOverwriteGlobalApplicationCommandsException("Code: ${response.status.value}, message: ${response.body() as String}")
-                } else if (response.status.value == 429) {
-                    rateLimitToMilliseconds(response)
-                    return@promise bulkOverwriteGlobalApplicationCommands(
-                        applicationCommands
-                    ).await()
-                } else {
-                    return@promise response.body()
-                }
+            return if (response.status.value != 200 && response.status.value != 429) {
+                throw BulkOverwriteGlobalApplicationCommandsException("Code: ${response.status.value}, message: ${response.body() as String}")
+            } else if (response.status.value == 429) {
+                rateLimitToMilliseconds(response)
+                bulkOverwriteGlobalApplicationCommands(applicationCommands)
+            } else {
+                response.body()
             }
+        }
 
         actual inner class Guild(private val guildId: String) {
             /**
              * Fetch all of the guild commands for your application for a specific guild. Returns an array of application command objects.
              * @exception GetGuildApplicationCommandsException if the Discord API didn't return `200 OK`.
              */
-            fun getGuildApplicationCommands(withLocalizations: Boolean? = null): Promise<Array<ApplicationCommand>> =
-                GlobalScope.promise {
-                    val response =
-                        ktorClient.get("/applications/$applicationId/guilds/$guildId/commands") {
-                            if (withLocalizations == true) {
-                                url {
-                                    parameters.append(
-                                        "with_localizations", "1"
-                                    )
-                                }
+            suspend fun getGuildApplicationCommands(withLocalizations: Boolean? = null): Array<ApplicationCommand> {
+                val response =
+                    ktorClient.get("/applications/$applicationId/guilds/$guildId/commands") {
+                        if (withLocalizations == true) {
+                            url {
+                                parameters.append(
+                                    "with_localizations", "1"
+                                )
                             }
                         }
-
-                    if (response.status.value != 200 && response.status.value != 429) {
-                        throw GetGuildApplicationCommandsException("Code: ${response.status.value}, message: ${response.body() as String}")
-                    } else if (response.status.value == 429) {
-                        rateLimitToMilliseconds(response)
-                        return@promise getGuildApplicationCommands(withLocalizations).await()
-                    } else {
-                        return@promise response.body()
                     }
+
+                return if (response.status.value != 200 && response.status.value != 429) {
+                    throw GetGuildApplicationCommandsException("Code: ${response.status.value}, message: ${response.body() as String}")
+                } else if (response.status.value == 429) {
+                    rateLimitToMilliseconds(response)
+                    getGuildApplicationCommands(withLocalizations)
+                } else {
+                    response.body()
                 }
+            }
 
             /**
              * Create a new guild command. New guild commands will be available in the guild immediately. Returns an application command object.
              * @exception CreateGuildApplicationCommandException if the Discord API didn't return `200 OK` or `201 Created`.
              */
-            fun createGuildApplicationCommand(applicationCommand: ApplicationCommandCreate): Promise<ApplicationCommand> =
-                GlobalScope.promise {
-                    val response =
-                        ktorClient.post("/applications/$applicationId/guilds/$guildId/commands") {
-                            contentType(ContentType.Application.Json)
-                            setBody(applicationCommand)
-                        }
-
-                    if (response.status.value != 200 && response.status.value != 201 && response.status.value != 429) {
-                        throw CreateGuildApplicationCommandException("Code: ${response.status.value}, message: ${response.body() as String}")
-                    } else if (response.status.value == 429) {
-                        rateLimitToMilliseconds(response)
-                        return@promise createGuildApplicationCommand(applicationCommand).await()
-                    } else {
-                        return@promise response.body()
+            suspend fun createGuildApplicationCommand(applicationCommand: ApplicationCommandCreate): ApplicationCommand {
+                val response =
+                    ktorClient.post("/applications/$applicationId/guilds/$guildId/commands") {
+                        contentType(ContentType.Application.Json)
+                        setBody(applicationCommand)
                     }
+
+                return if (response.status.value != 200 && response.status.value != 201 && response.status.value != 429) {
+                    throw CreateGuildApplicationCommandException("Code: ${response.status.value}, message: ${response.body() as String}")
+                } else if (response.status.value == 429) {
+                    rateLimitToMilliseconds(response)
+                    createGuildApplicationCommand(applicationCommand)
+                } else {
+                    response.body()
                 }
+            }
 
             /**
              * Fetch all of the guild commands for your application for a specific guild. Returns an array of application command objects.
              * @exception GetGuildApplicationCommandException if the Discord API didn't return `200 OK`.
              */
-            fun getGuildApplicationCommand(commandId: String): Promise<ApplicationCommand> =
-                GlobalScope.promise {
-                    val response =
-                        ktorClient.get("/applications/$applicationId/guilds/$guildId/commands/$commandId")
+            suspend fun getGuildApplicationCommand(commandId: String): ApplicationCommand {
+                val response =
+                    ktorClient.get("/applications/$applicationId/guilds/$guildId/commands/$commandId")
 
-                    if (response.status.value != 200 && response.status.value != 429) {
-                        throw GetGuildApplicationCommandException("Code: ${response.status.value}, message: ${response.body() as String}")
-                    } else if (response.status.value == 429) {
-                        rateLimitToMilliseconds(response)
-                        return@promise getGuildApplicationCommand(commandId).await()
-                    } else {
-                        return@promise response.body()
-                    }
+                return if (response.status.value != 200 && response.status.value != 429) {
+                    throw GetGuildApplicationCommandException("Code: ${response.status.value}, message: ${response.body() as String}")
+                } else if (response.status.value == 429) {
+                    rateLimitToMilliseconds(response)
+                    getGuildApplicationCommand(commandId)
+                } else {
+                    response.body()
                 }
+            }
 
             /**
              * Edit a guild command. Updates for guild commands will be available immediately. Returns an application command object. All fields are optional, but any fields provided will entirely overwrite the existing values of those fields.
              * @exception EditGuildApplicationCommandException if the Discord API didn't return `200 OK`.
              */
-            fun editGuildApplicationCommand(
+            suspend fun editGuildApplicationCommand(
                 commandId: String,
                 applicationCommand: ApplicationCommandEdit,
-            ): Promise<ApplicationCommand> = GlobalScope.promise {
+            ): ApplicationCommand {
                 val response =
                     ktorClient.patch("/applications/$applicationId/guilds/$guildId/commands/$commandId") {
                         contentType(ContentType.Application.Json)
                         setBody(applicationCommand)
                     }
 
-                if (response.status.value != 200 && response.status.value != 429) {
+                return if (response.status.value != 200 && response.status.value != 429) {
                     throw EditGuildApplicationCommandException("Code: ${response.status.value}, message: ${response.body() as String}")
                 } else if (response.status.value == 429) {
                     rateLimitToMilliseconds(response)
-                    return@promise editGuildApplicationCommand(
+                    editGuildApplicationCommand(
                         commandId, applicationCommand
-                    ).await()
+                    )
                 } else {
-                    return@promise response.body()
+                    response.body()
                 }
             }
 
@@ -524,42 +477,38 @@ import kotlinx.serialization.json.Json
              * Delete a guild command.
              * @exception DeleteGuildApplicationCommandException if the Discord API didn't return `204 No Content`.
              */
-            fun deleteGuildApplicationCommand(commandId: String): Promise<Unit> =
-                GlobalScope.promise {
-                    val response =
-                        ktorClient.delete("/applications/$applicationId/guilds/$guildId/commands/$commandId")
+            suspend fun deleteGuildApplicationCommand(commandId: String) {
+                val response =
+                    ktorClient.delete("/applications/$applicationId/guilds/$guildId/commands/$commandId")
 
-                    if (response.status.value != 204 && response.status.value != 429) {
-                        throw DeleteGuildApplicationCommandException("Code: ${response.status.value}, message: ${response.body() as String}")
-                    } else if (response.status.value == 429) {
-                        rateLimitToMilliseconds(response)
-                        deleteGuildApplicationCommand(commandId).await()
-                    }
+                if (response.status.value != 204 && response.status.value != 429) {
+                    throw DeleteGuildApplicationCommandException("Code: ${response.status.value}, message: ${response.body() as String}")
+                } else if (response.status.value == 429) {
+                    rateLimitToMilliseconds(response)
+                    deleteGuildApplicationCommand(commandId)
                 }
+            }
 
             /**
              * Takes a list of application commands, overwriting the existing command list for this application for the targeted guild. Returns an array of application command objects.
              * @exception BulkOverwriteGuildApplicationCommandsException if the Discord API didn't return `200 OK`.
              */
-            fun bulkOverwriteGuildApplicationCommands(applicationCommands: Array<ApplicationCommandCreate>): Promise<Array<ApplicationCommand>> =
-                GlobalScope.promise {
-                    val response =
-                        ktorClient.put("/applications/$applicationId/guilds/$guildId/commands") {
-                            contentType(ContentType.Application.Json)
-                            setBody(applicationCommands)
-                        }
-
-                    if (response.status.value != 200 && response.status.value != 429) {
-                        throw BulkOverwriteGuildApplicationCommandsException("Code: ${response.status.value}, message: ${response.body() as String}")
-                    } else if (response.status.value == 429) {
-                        rateLimitToMilliseconds(response)
-                        return@promise bulkOverwriteGuildApplicationCommands(
-                            applicationCommands
-                        ).await()
-                    } else {
-                        return@promise response.body()
+            suspend fun bulkOverwriteGuildApplicationCommands(applicationCommands: Array<ApplicationCommandCreate>): Array<ApplicationCommand> {
+                val response =
+                    ktorClient.put("/applications/$applicationId/guilds/$guildId/commands") {
+                        contentType(ContentType.Application.Json)
+                        setBody(applicationCommands)
                     }
+
+                return if (response.status.value != 200 && response.status.value != 429) {
+                    throw BulkOverwriteGuildApplicationCommandsException("Code: ${response.status.value}, message: ${response.body() as String}")
+                } else if (response.status.value == 429) {
+                    rateLimitToMilliseconds(response)
+                    bulkOverwriteGuildApplicationCommands(applicationCommands)
+                } else {
+                    response.body()
                 }
+            }
         }
     }
 }

--- a/src/jvmMain/kotlin/KtDiscord.kt
+++ b/src/jvmMain/kotlin/KtDiscord.kt
@@ -56,7 +56,7 @@ import kotlinx.coroutines.delay
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
-actual class KtDiscordClient actual constructor(
+actual class KtDiscord actual constructor(
     private val applicationId: String,
     private val botToken: String,
 ) {


### PR DESCRIPTION
Since JetBrains deprecated the legacy JS compiler before the replacement IR compiler reached feature parity, suspendible functions are not usable within the Kotlin/JS version because these cannot be exported directly to JavaScript. By disabling JavaScript builds we can ensure that the Kotlin/JVM and Kotlin/JS libraries have the same API.